### PR TITLE
replace <p>...</p> by paragraph markdown syntax

### DIFF
--- a/src/formatters.js
+++ b/src/formatters.js
@@ -92,7 +92,7 @@ function replaceOl (doc) {
  * @return {String}           [description]
  */
 function replaceParagraph (doc) {
-  return makeRegex(pRegex, doc);
+  return makeRegex(pRegex, doc, null, '\n\n');
 }
 
 /**


### PR DESCRIPTION
In markdown, to create a paragraph, the line must be ended by a double
line breaker. (\n\n)